### PR TITLE
Step 11E‑2: Implement poll_once()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ instance/
 .vscode/
 analytics.png
 notes.md
+PR_BODY.md

--- a/logexp/poller.py
+++ b/logexp/poller.py
@@ -7,26 +7,44 @@ logger = logging.getLogger(__name__)
 
 class Poller:
     """
-    Step 11E — Poller skeleton.
+    Step 11E — Poller implementation (11E‑2: poll_once).
 
-    This class provides the structure for a simplified ingestion source.
-    No hardware access, no serial usage, and no ingestion integration yet.
+    This version implements a deterministic, test‑safe poll_once()
+    using a fake frame provider. No hardware, no serial, no threads.
     """
 
     def __init__(self, config, ingestion):
         self.config = config
         self.ingestion = ingestion
 
+    # ------------------------------------------------------------
+    # 11E‑2: Deterministic fake frame provider
+    # ------------------------------------------------------------
+    def get_frame(self):
+        """
+        Return a deterministic fake frame for testing.
+
+        Later steps (11E‑4+) will replace this with real serial input.
+        """
+        fake_value = self.config.get("FAKE_FRAME_VALUE", 42)
+        return {"value": fake_value}
+
+    # ------------------------------------------------------------
+    # 11E‑2: Implement poll_once()
+    # ------------------------------------------------------------
     def poll_once(self):
         """
         Read one frame and hand it to ingestion.
-        Implementation added in later 11E commits.
         """
-        raise NotImplementedError("poll_once() not yet implemented")
+        frame = self.get_frame()
 
+        # Ingestion is responsible for validation and persistence.
+        self.ingestion.ingest(frame)
+
+        return frame
+
+    # ------------------------------------------------------------
+    # 11E‑1: Still unimplemented
+    # ------------------------------------------------------------
     def poll_forever(self):
-        """
-        Loop around poll_once().
-        Implementation added in later 11E commits.
-        """
         raise NotImplementedError("poll_forever() not yet implemented")

--- a/tests/unit/test_poller_once.py
+++ b/tests/unit/test_poller_once.py
@@ -1,0 +1,26 @@
+# tests/unit/test_poller_once.py
+
+from logexp.poller import Poller
+
+
+class FakeIngestion:
+    def __init__(self):
+        self.received = []
+
+    def ingest(self, frame):
+        self.received.append(frame)
+
+
+def test_poll_once_returns_frame_and_calls_ingestion():
+    # Arrange
+    config = {"FAKE_FRAME_VALUE": 123}
+    ingestion = FakeIngestion()
+    poller = Poller(config=config, ingestion=ingestion)
+
+    # Act
+    frame = poller.poll_once()
+
+    # Assert
+    assert frame == {"value": 123}
+    assert ingestion.received == [{"value": 123}]
+    assert len(ingestion.received) == 1


### PR DESCRIPTION
### Step 11E‑2: Implement `poll_once()`

This PR introduces the first functional behavior in the new poller subsystem.
It implements a deterministic, test‑safe `poll_once()` method using a
config‑driven fake frame provider. No hardware, serial access, threads, or
infinite loops are introduced at this stage.

### What’s Included
- Adds a `get_frame()` helper that returns a deterministic fake frame
  (`{"value": <FAKE_FRAME_VALUE>}`) based on configuration.
- Implements `poll_once()` to:
  - obtain a frame from `get_frame()`
  - hand the frame to the ingestion subsystem via `ingestion.ingest()`
  - return the frame for test visibility
- Leaves `poll_forever()` unimplemented (reserved for Step 11E‑3).

### Goals
- Establish a safe, deterministic ingestion path for a single frame.
- Avoid any hardware or serial dependencies.
- Keep the poller import‑safe and test‑safe.
- Provide a stable contract for future poller behavior.

### Validation
- Added a new test: `tests/unit/test_poller_once.py`
  - Confirms `poll_once()` returns the expected frame.
  - Confirms ingestion receives exactly one frame.
  - Confirms deterministic behavior via config.
- All 33 tests pass.
- No changes to runtime behavior.
- No background threads started.
- No hardware touched.

This PR is safe to merge and sets the stage for Step 11E‑3 (`poll_forever()`).
