### PR TITLE
Step 11E‑3: Implement poll_forever()

### DIFF
--- a/logexp/poller.py
+++ b/logexp/poller.py
@@ -7,10 +7,11 @@ logger = logging.getLogger(__name__)
 
 class Poller:
     """
-    Step 11E — Poller implementation (11E‑2: poll_once).
+    Step 11E — Poller implementation.
 
-    This version implements a deterministic, test‑safe poll_once()
-    using a fake frame provider. No hardware, no serial, no threads.
+    11E‑1: skeleton
+    11E‑2: poll_once()
+    11E‑3: poll_forever() loop (deterministic, test‑safe)
     """
 
     def __init__(self, config, ingestion):
@@ -21,30 +22,28 @@ class Poller:
     # 11E‑2: Deterministic fake frame provider
     # ------------------------------------------------------------
     def get_frame(self):
-        """
-        Return a deterministic fake frame for testing.
-
-        Later steps (11E‑4+) will replace this with real serial input.
-        """
         fake_value = self.config.get("FAKE_FRAME_VALUE", 42)
         return {"value": fake_value}
 
     # ------------------------------------------------------------
-    # 11E‑2: Implement poll_once()
+    # 11E‑2: poll_once()
     # ------------------------------------------------------------
     def poll_once(self):
-        """
-        Read one frame and hand it to ingestion.
-        """
         frame = self.get_frame()
-
-        # Ingestion is responsible for validation and persistence.
         self.ingestion.ingest(frame)
-
         return frame
 
     # ------------------------------------------------------------
-    # 11E‑1: Still unimplemented
+    # 11E‑3: poll_forever()
     # ------------------------------------------------------------
     def poll_forever(self):
-        raise NotImplementedError("poll_forever() not yet implemented")
+        """
+        Loop around poll_once() a finite number of times.
+
+        This is intentionally deterministic and test‑safe.
+        No threads, no hardware, no serial.
+        """
+        max_frames = self.config.get("MAX_FRAMES", 10)
+
+        for _ in range(max_frames):
+            self.poll_once()

--- a/tests/unit/test_poller_forever.py
+++ b/tests/unit/test_poller_forever.py
@@ -1,0 +1,28 @@
+# tests/unit/test_poller_forever.py
+
+from logexp.poller import Poller
+
+
+class FakeIngestion:
+    def __init__(self):
+        self.received = []
+
+    def ingest(self, frame):
+        self.received.append(frame)
+
+
+def test_poll_forever_calls_poll_once_repeatedly():
+    # Arrange
+    config = {
+        "FAKE_FRAME_VALUE": 7,
+        "MAX_FRAMES": 5,
+    }
+    ingestion = FakeIngestion()
+    poller = Poller(config=config, ingestion=ingestion)
+
+    # Act
+    poller.poll_forever()
+
+    # Assert
+    assert len(ingestion.received) == 5
+    assert ingestion.received == [{"value": 7}] * 5


### PR DESCRIPTION
### Step 11E‑3: Implement `poll_forever()`

This PR introduces the looping behavior for the new poller subsystem.
The implementation is deterministic, finite, and test‑safe. It loops
around `poll_once()` a configurable number of times without starting
threads or touching hardware.

### What’s Included
- Adds `poll_forever()` with a finite loop controlled by `MAX_FRAMES`
- Reuses the deterministic `poll_once()` and `get_frame()` from 11E‑2
- No serial access, no hardware, no background threads

### Goals
- Establish a safe looping mechanism for the poller
- Keep behavior deterministic for testing
- Avoid any runtime side effects or blocking behavior

### Validation
- Added new test: `tests/unit/test_poller_forever.py`
  - Confirms `poll_forever()` calls `poll_once()` repeatedly
  - Confirms ingestion receives exactly `MAX_FRAMES` frames
- All tests pass
- No changes to runtime behavior
- No hardware touched
